### PR TITLE
Added python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 install:
-  - pip install -r requirements.txt --use-mirrors
+  - pip install -r requirements.txt
 script:
   - python -m test

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,16 @@ import os
 
 from setuptools import setup, find_packages
 
+
 def read(*paths):
     """Build a file path from *paths* and return the contents."""
     with open(os.path.join(*paths), 'r') as f:
         return f.read()
 
+
 setup(
     name='sumproduct',
-    version='0.0.6',
+    version='0.0.7',
     description='The sum-product algorithm. (Loopy) Belief Propagation (message passing) for factor graphs',
     long_description=(read('README.rst')),
     url='http://github.com/ilyakava/sumproduct/',
@@ -26,9 +28,9 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
         'Intended Audience :: Science/Research',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
-)
+    ])

--- a/sumproduct.py
+++ b/sumproduct.py
@@ -1,41 +1,42 @@
 import numpy as np
-from math import isinf
-import pdb
+
 
 class Node:
-  def __init__(self, name):
-    self.connections = []
-    self.inbox = {} # messages recieved
-    self.name = name
+    def __init__(self, name):
+        self.connections = []
+        self.inbox = {}  # messages recieved
+        self.name = name
 
-  def append(self, to_node):
-    """
+    def append(self, to_node):
+        """
     Mutates the to AND from node!
     """
-    self.connections.append(to_node)
-    to_node.connections.append(self)
+        self.connections.append(to_node)
+        to_node.connections.append(self)
 
-  def deliver(self, step_num, mu):
-    """
+    def deliver(self, step_num, mu):
+        """
     Ensures that inbox is keyed by a step number
     """
-    if self.inbox.get(step_num):
-      self.inbox[step_num].append(mu)
-    else:
-      self.inbox[step_num] = [mu]
+        if self.inbox.get(step_num):
+            self.inbox[step_num].append(mu)
+        else:
+            self.inbox[step_num] = [mu]
+
 
 class Factor(Node):
-  """
+    """
   NOTE: For the Factor nodes in the graph, it will be assumed
   that the connections are created in the same exact order
   as the potentials' dimensions are given
   """
-  def __init__(self, name, potentials):
-    self.p = potentials
-    Node.__init__(self, name)
 
-  def make_message(self, recipient):
-    """
+    def __init__(self, name, potentials):
+        self.p = potentials
+        Node.__init__(self, name)
+
+    def make_message(self, recipient):
+        """
     Does NOT mutate the Factor node!
 
     NOTE that using the log rule before 5.1.42 in BRML by David
@@ -55,21 +56,23 @@ class Factor(Node):
     Note that max_lambda in 5.1.42 is NOT a element-wise maximum (and
     therefore a matrix), it is a scalar.
     """
-    if not len(self.connections) == 1:
-      unfiltered_mus = self.inbox[max(self.inbox.keys())]
-      mus = [mu for mu in unfiltered_mus if not mu.from_node == recipient]
-      all_mus = [self.reformat_mu(mu) for mu in mus]
-      lambdas = np.array([np.log(mu) for mu in all_mus])
-      max_lambdas = np.nan_to_num(lambdas.flatten())
-      max_lambda = max(max_lambdas)
-      result = reduce(lambda a,e: a + e, lambdas) - max_lambda
-      product_output = np.multiply(self.p, np.exp(result))
-      return np.exp(np.log(self.summation(product_output, recipient)) + max_lambda)
-    else:
-      return self.summation(self.p, recipient)
+        if not len(self.connections) == 1:
+            unfiltered_mus = self.inbox[max(self.inbox.keys())]
+            mus = [mu for mu in unfiltered_mus
+                   if not mu.from_node == recipient]
+            all_mus = [self.reformat_mu(mu) for mu in mus]
+            lambdas = np.array([np.log(mu) for mu in all_mus])
+            max_lambdas = np.nan_to_num(lambdas.flatten())
+            max_lambda = max(max_lambdas)
+            result = sum(lambdas) - max_lambda
+            product_output = np.multiply(self.p, np.exp(result))
+            return np.exp(
+                np.log(self.summation(product_output, recipient)) + max_lambda)
+        else:
+            return self.summation(self.p, recipient)
 
-  def reformat_mu(self, mu):
-    """
+    def reformat_mu(self, mu):
+        """
     Returns the given mu's val reformatted to be the same
     dimensions as self.p, ensuring that mu's values are
     expanded in the correct axes.
@@ -108,125 +111,128 @@ class Factor(Node):
       ]
     ])
     """
-    dims = self.p.shape
-    states = mu.val
-    which_dim = self.connections.index(mu.from_node) # raises err
-    assert dims[which_dim] is len(states)
+        dims = self.p.shape
+        states = mu.val
+        which_dim = self.connections.index(mu.from_node)  # raises err
+        assert dims[which_dim] is len(states)
 
-    acc = np.ones(dims)
-    for coord in np.ndindex(dims):
-      i = coord[which_dim]
-      acc[coord] *= states[i]
-    return acc
+        acc = np.ones(dims)
+        for coord in np.ndindex(dims):
+            i = coord[which_dim]
+            acc[coord] *= states[i]
+        return acc
 
-  def summation(self, p, node):
-    """
+    def summation(self, p, node):
+        """
     Does NOT mutate the factor node.
 
     Sum over all states not in the node.
     Similar to reformat_mu in strategy.
     """
-    dims = p.shape
-    which_dim = self.connections.index(node)
-    out = np.zeros(node.size)
-    assert dims[which_dim] is node.size
-    for coord in np.ndindex(dims):
-      i = coord[which_dim]
-      out[i] += p[coord]
-    return out
+        dims = p.shape
+        which_dim = self.connections.index(node)
+        out = np.zeros(node.size)
+        assert dims[which_dim] is node.size
+        for coord in np.ndindex(dims):
+            i = coord[which_dim]
+            out[i] += p[coord]
+        return out
+
 
 class Variable(Node):
-  def __init__(self, name, size):
-    self.bfmarginal = None
-    self.size = size
-    Node.__init__(self, name)
+    def __init__(self, name, size):
+        self.bfmarginal = None
+        self.size = size
+        Node.__init__(self, name)
 
-  def marginal(self):
-    """
+    def marginal(self):
+        """
     Life saving normalizations:
 
     sum_logs - max(sum_logs) <- before exponentiating
     and rem_inf
     """
-    if len(self.inbox):
-      mus = self.inbox[max(self.inbox.keys())]
-      log_vals = [np.log(mu.val) for mu in mus]
-      valid_log_vals = [np.nan_to_num(lv) for lv in log_vals]
-      sum_logs = reduce(lambda a, e: a+e, valid_log_vals)
-      valid_sum_logs = sum_logs - max(sum_logs) # IMPORANT!
-      prod = np.exp(valid_sum_logs)
-      return prod / sum(prod) # normalize
-    else:
-      # first time called: uniform
-      return np.ones(self.size) / self.size
+        if len(self.inbox):
+            mus = self.inbox[max(self.inbox.keys())]
+            log_vals = [np.log(mu.val) for mu in mus]
+            valid_log_vals = [np.nan_to_num(lv) for lv in log_vals]
+            sum_logs = sum(valid_log_vals)
+            valid_sum_logs = sum_logs - max(sum_logs)  # IMPORANT!
+            prod = np.exp(valid_sum_logs)
+            return prod / sum(prod)  # normalize
+        else:
+            # first time called: uniform
+            return np.ones(self.size) / self.size
 
-  def latex_marginal(self):
-    """
+    def latex_marginal(self):
+        """
     same as marginal() but returns a nicely formatted latex string
     """
-    data = self.marginal()
-    data_str = ' & '.join([str(d) for d in data])
-    tabular = '|' + ' | '.join(['l' for i in range(self.size)]) + '|'
-    return ("$$p(\mathrm{" + self.name + "}) = \\begin{tabular}{" +
-      tabular +
-      '} \hline' +
-      data_str +
-      '\\\\ \hline \end{tabular}$$')
+        data = self.marginal()
+        data_str = ' & '.join([str(d) for d in data])
+        tabular = '|' + ' | '.join(['l' for i in range(self.size)]) + '|'
+        return ("$$p(\mathrm{" + self.name + "}) = \\begin{tabular}{" + tabular
+                + '} \hline' + data_str + '\\\\ \hline \end{tabular}$$')
 
-  def make_message(self, recipient):
-    """
+    def make_message(self, recipient):
+        """
     Follows log rule in 5.1.38 in BRML by David Barber
     b/c of numerical issues
     """
-    if not len(self.connections) == 1:
-      unfiltered_mus = self.inbox[max(self.inbox.keys())]
-      mus = [mu for mu in unfiltered_mus if not mu.from_node == recipient]
-      log_vals = [np.log(mu.val) for mu in mus]
-      return np.exp(reduce(lambda a,e: a+e, log_vals))
-    else:
-      return np.ones(self.size)
+        if not len(self.connections) == 1:
+            unfiltered_mus = self.inbox[max(self.inbox.keys())]
+            mus = [mu for mu in unfiltered_mus
+                   if not mu.from_node == recipient]
+            log_vals = [np.log(mu.val) for mu in mus]
+            return np.exp(sum(log_vals))
+        else:
+            return np.ones(self.size)
+
 
 class Mu:
-  """
+    """
   An object to represent a message being passed
   a to_node attribute isn't needed since that will be clear from
   whose inbox the Mu is sitting in
   """
-  def __init__(self, from_node, val):
-    self.from_node = from_node
-    # this normalization is necessary
-    self.val = val.flatten() / sum(val.flatten())
+
+    def __init__(self, from_node, val):
+        self.from_node = from_node
+        # this normalization is necessary
+        self.val = val.flatten() / sum(val.flatten())
+
 
 class FactorGraph:
-  def __init__(self, first_node=None, silent=False, debug=False):
-    self.nodes = {}
-    self.silent = silent
-    self.debug = debug
-    if first_node:
-      self.nodes[first_node.name] = first_node
+    def __init__(self, first_node=None, silent=False, debug=False):
+        self.nodes = {}
+        self.silent = silent
+        self.debug = debug
+        if first_node:
+            self.nodes[first_node.name] = first_node
 
-  def add(self, node):
-    assert node not in self.nodes
-    self.nodes[node.name] = node
+    def add(self, node):
+        assert node not in self.nodes
+        self.nodes[node.name] = node
 
-  def connect(self, name1, name2):
-    # no need to assert since dict lookup will raise err
-    self.nodes[name1].append(self.nodes[name2])
+    def connect(self, name1, name2):
+        # no need to assert since dict lookup will raise err
+        self.nodes[name1].append(self.nodes[name2])
 
-  def append(self, from_node_name, to_node):
-    assert from_node_name in self.nodes
-    tnn = to_node.name
-    # add the to_node to the graph if it is not already there
-    if not (self.nodes.get(tnn, 0)):
-      self.nodes[tnn] = to_node
-    self.nodes[from_node_name].append(self.nodes[tnn])
-    return self
+    def append(self, from_node_name, to_node):
+        assert from_node_name in self.nodes
+        tnn = to_node.name
+        # add the to_node to the graph if it is not already there
+        if not (self.nodes.get(tnn, 0)):
+            self.nodes[tnn] = to_node
+        self.nodes[from_node_name].append(self.nodes[tnn])
+        return self
 
-  def leaf_nodes(self):
-    return [node for node in self.nodes.values() if len(node.connections) ==  1]
+    def leaf_nodes(self):
+        return [node for node in self.nodes.values()
+                if len(node.connections) == 1]
 
-  def observe(self, name, state):
-    """
+    def observe(self, name, state):
+        """
     Mutates the factors connected to Variable with name!
 
     @param state: Ordinal state starting at ONE (1)
@@ -238,37 +244,37 @@ class FactorGraph:
     variable node is severed (although it remains in the graph
     to give a uniform marginal when asked).
     """
-    node = self.nodes[name]
-    assert isinstance(node, Variable)
-    assert node.size >= state
-    assert state, "state is obsered on an ordinal scale starting at ONE (1)"
-    for factor in [c for c in node.connections if isinstance(c, Factor)]:
-      delete_axis = factor.connections.index(node)
-      delete_dims = range(node.size)
-      delete_dims.pop(state - 1)
-      sliced = np.delete(factor.p, delete_dims, delete_axis)
-      factor.p = np.squeeze(sliced)
-      factor.connections.remove(node)
-      assert len(factor.p.shape) is len(factor.connections)
-    node.connections = [] # so that they don't pass messages
+        node = self.nodes[name]
+        assert isinstance(node, Variable)
+        assert node.size >= state
+        assert state, "state is obsered on an ordinal scale starting at ONE(1)"
+        for factor in [c for c in node.connections if isinstance(c, Factor)]:
+            delete_axis = factor.connections.index(node)
+            delete_dims = range(node.size)
+            delete_dims.pop(state - 1)
+            sliced = np.delete(factor.p, delete_dims, delete_axis)
+            factor.p = np.squeeze(sliced)
+            factor.connections.remove(node)
+            assert len(factor.p.shape) is len(factor.connections)
+        node.connections = []  # so that they don't pass messages
 
-  def export_marginals(self):
-    return dict([
-      (n.name, n.marginal())
-      for n in self.nodes.values()
-      if isinstance(n, Variable)])
+    def export_marginals(self):
+        return dict([
+            (n.name, n.marginal()) for n in self.nodes.values()
+            if isinstance(n, Variable)
+        ])
 
-  @staticmethod
-  def compare_marginals(m1, m2):
-    """
+    @staticmethod
+    def compare_marginals(m1, m2):
+        """
     For testing the difference between marginals across a graph at
     two different iteration states, in order to declare convergence.
     """
-    assert not len(np.setdiff1d(m1.keys(), m2.keys()))
-    return sum([sum(np.absolute(m1[k] - m2[k])) for k in m1.keys()])
+        assert not len(np.setdiff1d(m1.keys(), m2.keys()))
+        return sum([sum(np.absolute(m1[k] - m2[k])) for k in m1.keys()])
 
-  def compute_marginals(self, max_iter=500, tolerance=1e-6, error_fun=None):
-    """
+    def compute_marginals(self, max_iter=500, tolerance=1e-6, error_fun=None):
+        """
     sum-product algorithm
 
     @param error_fun: a custom error function that takes two arguments
@@ -296,50 +302,54 @@ class FactorGraph:
     up working best as a max sum-product algorithm as high
     probabilities dominate heavily when the tolerance is very small
     """
-    # for keeping track of state
-    epsilons = [1]
-    step = 0
-	# for inbox clearance
-    for node in self.nodes.values():
-      node.inbox.clear()
-    # for testing convergence
-    cur_marginals = self.export_marginals()
-    # initialization
-    for node in self.nodes.values():
-      if isinstance(node, Variable):
-        message = Mu(node, np.ones(node.size))
-        for recipient in node.connections:
-          recipient.deliver(step, message)
+        # for keeping track of state
+        epsilons = [1]
+        step = 0
+        # for inbox clearance
+        for node in self.nodes.values():
+            node.inbox.clear()
+        # for testing convergence
+        cur_marginals = self.export_marginals()
+        # initialization
+        for node in self.nodes.values():
+            if isinstance(node, Variable):
+                message = Mu(node, np.ones(node.size))
+                for recipient in node.connections:
+                    recipient.deliver(step, message)
 
-    # propagation (w/ termination conditions)
-    while (step < max_iter) and tolerance < epsilons[-1]:
-      last_marginals = cur_marginals
-      step += 1
-      if not self.silent:
-        print 'epsilon: ' + str(epsilons[-1]) + ' | ' + str(step) + '-'*20
-      factors = [n for n in self.nodes.values() if isinstance(n, Factor)]
-      variables = [n for n in self.nodes.values() if isinstance(n, Variable)]
-      senders = factors + variables
-      for sender in senders:
-        next_recipients = sender.connections
-        for recipient in next_recipients:
-          if self.debug:
-            print sender.name + ' -> ' + recipient.name
-          val = sender.make_message(recipient)
-          message = Mu(sender, val)
-          recipient.deliver(step, message)
-      cur_marginals = self.export_marginals()
-      if error_fun:
-        epsilons.append(error_fun(cur_marginals, last_marginals))
-      else:
-        epsilons.append(self.compare_marginals(cur_marginals, last_marginals))
-    if not self.silent:
-      print 'X'*50
-      print 'final epsilon after ' + str(step) + ' iterations = ' + str(epsilons[-1])
-    return epsilons[1:] # skip only the first, see docstring above
+        # propagation (w/ termination conditions)
+        while (step < max_iter) and tolerance < epsilons[-1]:
+            last_marginals = cur_marginals
+            step += 1
+            if not self.silent:
+                epsilon = 'epsilon: ' + str(epsilons[-1])
+                print(epsilon + ' | ' + str(step) + '-' * 20)
+            factors = [n for n in self.nodes.values() if isinstance(n, Factor)]
+            variables = [n for n in self.nodes.values()
+                         if isinstance(n, Variable)]
+            senders = factors + variables
+            for sender in senders:
+                next_recipients = sender.connections
+                for recipient in next_recipients:
+                    if self.debug:
+                        print(sender.name + ' -> ' + recipient.name)
+                    val = sender.make_message(recipient)
+                    message = Mu(sender, val)
+                    recipient.deliver(step, message)
+            cur_marginals = self.export_marginals()
+            if error_fun:
+                epsilons.append(error_fun(cur_marginals, last_marginals))
+            else:
+                epsilons.append(
+                    self.compare_marginals(cur_marginals, last_marginals))
+        if not self.silent:
+            print('X' * 50)
+            print('final epsilon after ' + str(step) + ' iterations = ' + str(
+                epsilons[-1]))
+        return epsilons[1:]  # skip only the first, see docstring above
 
-  def brute_force(self):
-    """
+    def brute_force(self):
+        """
     Main strategy of this code was gleaned from:
     http://cs.brown.edu/courses/cs242/assignments/hw1code.zip
 
@@ -357,28 +367,29 @@ class FactorGraph:
     - iterate through variables
       - for each variable sum over all other variables
     """
-    variables = [v for v in self.nodes.values() if isinstance(v, Variable)]
+        variables = [v for v in self.nodes.values() if isinstance(v, Variable)]
 
-    var_dims = [v.size for v in variables]
-    N = len(var_dims)
-    assert N < 32, "max number of vars for brute force is 32 (numpy's matrix dim limit)"
-    log_joint_acc = np.zeros(var_dims)
-    for factor in [f for f in self.nodes.values() if isinstance(f, Factor)]:
-      # dimensions that will matter for this factor
-      which_dims = [variables.index(v) for v in factor.connections]
-      factor_acc = np.ones(var_dims)
-      for joint_coord in np.ndindex(tuple(var_dims)):
-        factor_coord = tuple([joint_coord[i] for i in which_dims])
-        factor_acc[joint_coord] *= factor.p[factor_coord]
-      log_joint_acc += np.log(factor_acc)
-    log_joint_acc -= np.max(log_joint_acc) # to avoid numerical issues
-    joint_acc = np.exp(log_joint_acc) / np.sum(np.exp(log_joint_acc))
-    # compute marginals
-    for i, variable in enumerate(variables):
-      sum_dims = [j for j in range(N) if not j == i]
-      sum_dims.sort(reverse=True)
-      collapsing_marginal = joint_acc
-      for j in sum_dims:
-        collapsing_marginal = collapsing_marginal.sum(j) # lose 1 dim
-      variable.bfmarginal = collapsing_marginal
-    return variables
+        var_dims = [v.size for v in variables]
+        N = len(var_dims)
+        assert N < 32, "max number of vars for brute force is 32 (numpy's matrix dim limit)"
+        log_joint_acc = np.zeros(var_dims)
+        for factor in [f for f in self.nodes.values()
+                       if isinstance(f, Factor)]:
+            # dimensions that will matter for this factor
+            which_dims = [variables.index(v) for v in factor.connections]
+            factor_acc = np.ones(var_dims)
+            for joint_coord in np.ndindex(tuple(var_dims)):
+                factor_coord = tuple([joint_coord[i] for i in which_dims])
+                factor_acc[joint_coord] *= factor.p[factor_coord]
+            log_joint_acc += np.log(factor_acc)
+        log_joint_acc -= np.max(log_joint_acc)  # to avoid numerical issues
+        joint_acc = np.exp(log_joint_acc) / np.sum(np.exp(log_joint_acc))
+        # compute marginals
+        for i, variable in enumerate(variables):
+            sum_dims = [j for j in range(N) if not j == i]
+            sum_dims.sort(reverse=True)
+            collapsing_marginal = joint_acc
+            for j in sum_dims:
+                collapsing_marginal = collapsing_marginal.sum(j)  # lose 1 dim
+            variable.bfmarginal = collapsing_marginal
+        return variables

--- a/test.py
+++ b/test.py
@@ -1,11 +1,11 @@
 import unittest
 import numpy as np
-import pdb
 
 from sumproduct import Variable, Factor, FactorGraph, Mu
 
+
 class SimpleGraph(unittest.TestCase):
-  """
+    """
   This is the graph pictured in the readme.
 
   Learn more about this graphical model from exercise 8.10
@@ -13,99 +13,101 @@ class SimpleGraph(unittest.TestCase):
   and Machine Learning
   """
 
-  def createSimpleGraph(self):
-    # create the orphaned nodes
-    node_names = ['x1', 'x2', 'x3', 'x4']
-    dims = [2,3,2,2]
+    def createSimpleGraph(self):
+        # create the orphaned nodes
+        node_names = ['x1', 'x2', 'x3', 'x4']
+        dims = [2, 3, 2, 2]
 
-    # pad array just so that reference like x[1] later is easier to read
-    x = [None] + [Variable(node_names[i], dims[i]) for i in range(4)]
+        # pad array just so that reference like x[1] later is easier to read
+        x = [None] + [Variable(node_names[i], dims[i]) for i in range(4)]
 
-    f3 = Factor('f3', np.array([0.2, 0.8]))
-    f4 = Factor('f4', np.array([0.5, 0.5]))
+        f3 = Factor('f3', np.array([0.2, 0.8]))
+        f4 = Factor('f4', np.array([0.5, 0.5]))
 
-    # first index is x3, second index is x4, third index is x2
-    # looking at it like: arr[0][0][0]
-    f234 = Factor('f234', np.array([
-      [
-        [0.3,0.5,0.2],
-        [0.1,0.1,0.8]
-      ],
-      [
-        [0.9,0.05,0.05],
-        [0.2,0.7,0.1]
-      ]
-    ]))
+        # first index is x3, second index is x4, third index is x2
+        # looking at it like: arr[0][0][0]
+        f234 = Factor('f234', np.array([
+            [
+                [0.3, 0.5, 0.2], [0.1, 0.1, 0.8]
+            ], [
+                [0.9, 0.05, 0.05], [0.2, 0.7, 0.1]
+            ]
+        ]))
 
-    # first index is x2
-    f12 = Factor('f12', np.array([
-      [0.8,0.2],
-      [0.2,0.8],
-      [0.5,0.5]
-    ]))
+        # first index is x2
+        f12 = Factor('f12', np.array([[0.8, 0.2], [0.2, 0.8], [0.5, 0.5]]))
 
-    # attach nodes to graph in right order (connections matching
-    # factor's potential's dimensions order)
-    g = FactorGraph(x[3], silent=True)
-    g.append('x3', f234)
-    g.append('f234', x[4])
-    g.append('f234', x[2])
-    g.append('x2', f12)
-    g.append('f12', x[1])
-    g.append('x3', f3)
-    g.append('x4', f4)
-    return g
+        # attach nodes to graph in right order (connections matching
+        # factor's potential's dimensions order)
+        g = FactorGraph(x[3], silent=True)
+        g.append('x3', f234)
+        g.append('f234', x[4])
+        g.append('f234', x[2])
+        g.append('x2', f12)
+        g.append('f12', x[1])
+        g.append('x3', f3)
+        g.append('x4', f4)
+        return g
 
-  def setUp(self):
-    self.g = self.createSimpleGraph()
+    def setUp(self):
+        self.g = self.createSimpleGraph()
 
-  def testTwoIndependentInstances(self):
-    g1 = self.createSimpleGraph()
-    g2 = FactorGraph()
-    self.failUnless(len(g1.nodes))
-    self.failUnless(len(g2.nodes) == 0)
+    def testTwoIndependentInstances(self):
+        g1 = self.createSimpleGraph()
+        g2 = FactorGraph()
+        self.failUnless(len(g1.nodes))
+        self.failUnless(len(g2.nodes) == 0)
 
-  def testCustomErrorFunction(self):
-    func = lambda m1, m2: sum([sum(np.absolute(m1[k] - m2[k])) for k in m1.keys()])
-    self.g.compute_marginals(error_fun=func)
+    def testCustomErrorFunction(self):
+        def func(m1, m2):
+            return sum([sum(np.absolute(m1[k] - m2[k])) for k in m1.keys()])
 
-  def testSumProductInference(self):
-    self.g.compute_marginals()
-    self.failUnless(
-      np.allclose(self.g.nodes['x1'].marginal(), np.array([ 0.536,  0.464])))
-    self.failUnless(
-      np.allclose(self.g.nodes['x2'].marginal(), np.array([ 0.48,  0.36,  0.16])))
-    self.failUnless(
-      np.allclose(self.g.nodes['x3'].marginal(), np.array([ 0.2,  0.8])))
-    self.failUnless(
-      np.allclose(self.g.nodes['x4'].marginal(), np.array([ 0.5,  0.5])))
+        self.g.compute_marginals(error_fun=func)
 
-  def testBruteForceInference(self):
-    self.g.brute_force()
-    self.failUnless(
-      np.allclose(self.g.nodes['x1'].bfmarginal, np.array([ 0.536,  0.464])))
-    self.failUnless(
-      np.allclose(self.g.nodes['x2'].bfmarginal, np.array([ 0.48,  0.36,  0.16])))
-    self.failUnless(
-      np.allclose(self.g.nodes['x3'].bfmarginal, np.array([ 0.2,  0.8])))
-    self.failUnless(
-      np.allclose(self.g.nodes['x4'].bfmarginal, np.array([ 0.5,  0.5])))
+    def testSumProductInference(self):
+        self.g.compute_marginals()
+        self.failUnless(
+            np.allclose(self.g.nodes['x1'].marginal(), np.array([0.536, 0.464
+                                                                 ])))
+        self.failUnless(
+            np.allclose(self.g.nodes['x2'].marginal(), np.array([0.48, 0.36,
+                                                                 0.16])))
+        self.failUnless(
+            np.allclose(self.g.nodes['x3'].marginal(), np.array([0.2, 0.8])))
+        self.failUnless(
+            np.allclose(self.g.nodes['x4'].marginal(), np.array([0.5, 0.5])))
+
+    def testBruteForceInference(self):
+        self.g.brute_force()
+        self.failUnless(
+            np.allclose(self.g.nodes['x1'].bfmarginal, np.array([0.536, 0.464
+                                                                 ])))
+        self.failUnless(
+            np.allclose(self.g.nodes['x2'].bfmarginal, np.array([0.48, 0.36,
+                                                                 0.16])))
+        self.failUnless(
+            np.allclose(self.g.nodes['x3'].bfmarginal, np.array([0.2, 0.8])))
+        self.failUnless(
+            np.allclose(self.g.nodes['x4'].bfmarginal, np.array([0.5, 0.5])))
+
 
 class InboxToMarginal(unittest.TestCase):
-  def setUp(self):
-    node = Variable('bit', 2)
-    uniform = Mu(None, np.array([0.5,0.5]))
-    point = Mu(None, np.array([1.0,0.0]))
-    node.deliver(2, uniform)
-    node.deliver(2, point)
-    self.node = node
+    def setUp(self):
+        node = Variable('bit', 2)
+        uniform = Mu(None, np.array([0.5, 0.5]))
+        point = Mu(None, np.array([1.0, 0.0]))
+        node.deliver(2, uniform)
+        node.deliver(2, point)
+        self.node = node
 
-  def testFewHarshProbabilities(self):
-    self.failUnless(
-      np.allclose(self.node.marginal(), np.array([1.0, 0.0])))
+    def testFewHarshProbabilities(self):
+        self.failUnless(
+            np.allclose(self.node.marginal(), np.array([1.0, 0.0])))
+
 
 def main():
-  unittest.main()
+    unittest.main()
+
 
 if __name__ == '__main__':
-  main()
+    main()


### PR DESCRIPTION
Python 3 compatibility added.  This only required rewriting certain anonymous lambda reductions to `sum` calls, as well as putting parentheses around some `print` calls.

PEP8 compatibility has been improved using the default settings from YAPF.

All tests pass with Python 2 and Python 3.  The travis builds also successfully complete.